### PR TITLE
removed pkg-resources==0.0.0 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ matplotlib==3.0.2
 mpi4py==2.0.0
 networkx==2.2
 numpy==1.15.4
-pkg-resources==0.0.0
 pyparsing==2.3.0
 python-dateutil==2.7.5
 six==1.12.0


### PR DESCRIPTION
`pip install -r requirements.txt`
gives error with `pkg-resources==0.0.0` that is an ubuntu bug.